### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ Project 2 - Testing out Sprite by creating a block collision game. The goal of t
 using keyboards to control the block.
 
 Project 3 - A spin of the Space Invader game. The goal of the game is to get rid of all the bouncing block and ball by shooting at them.
+er


### PR DESCRIPTION
> Sorry can you provide more context for this? Why are we adding a dependency on CATS to this endpoint + what it seems like the clockIn endpoint in a later PR? Is this implying that we're blocking clock in if a courier has a single strike in CATS that they haven't acknowledged?

Yep, for account strikes, if a courier have any strikes in their account that they haven't acknowledged they won't be able to clock-in. Here's a link to how the new flow [looks](https://www.figma.com/file/YIjbLis7BTVLxolNpkn8yV/%5BAccount-%2B-Help%5D-Account-Strikes?node-id=671%3A17577). Essentially if a courier has any clock-in restrictions they would be blocked from the clock-in page.

> Can you also explain more on the DMGS revamp that's happening that requires these changes to provide the clock in restriction? What changes are going to need to be made to the actual clockIn endpoint in Courier?

On the old clock-in flow, couriers are allowed to toggle clock-in but they would be block if they have any restrictions. For this new flow, we would be separating it out such that we first check if the couriers have any clock-in restrictions. If they do they would be block from toggling clock-in. We took the chance to consolidate all of the current clock-in restrictions into this flow (Prop 22 hours worked, no active card pnp).

As for the clock-in rpc endpoint, we would be creating a new v2 endpoint that follows the same logic as the current clock-in. The only change would be that we consolidate the restrictions into one "clockInRestriction" and returning those into the metadata. 
In DMGs side, this would clean up how we're handling different restrictions currently (409 on no card activate and 200 on prop 22 hours worked). Such that for any restrictions we would return 409 containing restrictions and 200 for success. 

Lmk if this is confusing I could setup a call to provide more context/explain it